### PR TITLE
fix(linux): properly handle screen reconfigurations

### DIFF
--- a/src/Fl_Screen_Driver.cxx
+++ b/src/Fl_Screen_Driver.cxx
@@ -461,19 +461,12 @@ int Fl_Screen_Driver::scale_handler(int event)
 // use the startup time scaling value
 void Fl_Screen_Driver::use_startup_scale_factor()
 {
-  float factor;
-  char *p = 0;
+  char *p;
+  desktop_scale_factor();
   if ((p = fl_getenv("FLTK_SCALING_FACTOR"))) {
+    float factor = 1;
     sscanf(p, "%f", &factor);
-    // checks to prevent potential crash (factor <= 0) or very large factors
-    if (factor < 0.25) factor = 0.25;
-    else if (factor > 10.0) factor = 10.0;
-  }
-  else {
-    factor = desktop_scale_factor();
-  }
-  if (factor) {
-    for (int i = 0; i < screen_count(); i++)  scale(i, factor);
+    for (int i = 0; i < screen_count(); i++)  scale(i, factor * scale(i));
   }
 }
 
@@ -484,7 +477,6 @@ void Fl_Screen_Driver::open_display()
   static bool been_here = false;
   if (!been_here) {
     been_here = true;
-    screen_count(); // initialize, but ignore return value
     if (rescalable()) {
       use_startup_scale_factor();
       Fl::add_handler(Fl_Screen_Driver::scale_handler);

--- a/src/drivers/X11/Fl_X11_Screen_Driver.H
+++ b/src/drivers/X11/Fl_X11_Screen_Driver.H
@@ -33,6 +33,7 @@ class Fl_Window;
 
 class FL_EXPORT Fl_X11_Screen_Driver : public Fl_Screen_Driver 
 {
+    friend class Fl_Screen_Driver;
 protected:
   typedef struct {
     short x_org;
@@ -51,6 +52,7 @@ protected:
 
 public:
 #if USE_XFT // scaling does not work without Xft
+  float current_xft_dpi; // current value of the Xft.dpi X resource
   virtual APP_SCALING_CAPABILITY rescalable() { return PER_SCREEN_APP_SCALING; }
   virtual float scale(int n) {return screens[n].scale;}
   virtual void scale(int n, float f) { screens[n].scale = f;}


### PR DESCRIPTION
This is a port of several commits from upstream.
This commit can be entirely removed after moving anywhere after 8e9512330d1c172c2819cdca23f80dc188166f19

The changes were made between commit 11ed18a52e4b27c74d1aab3813aa41b0d1507d3f and 8e9512330d1c172c2819cdca23f80dc188166f19 (inclusive).